### PR TITLE
Rebase, Client-Certificates, Double/Split `authn` with Okta

### DIFF
--- a/gp-okta.conf
+++ b/gp-okta.conf
@@ -10,7 +10,7 @@ totp.google = ABCDEFGHIJKLMNOP
 gateway = Manual ny1-gw.example.com
 #cert = path-to-client-cert-as-unencrypted-pem-file.pem
 #openconnect_cmd = sudo openconnect
-openconnect_args =                    # optional arguments to openconnect, probably you might want to repeat the cert here (if used above) with --certificate=xxx
+openconnect_args =                    # optional arguments to openconnect
 execute = 0                           # execute openconnect command
 another_dance = 0                     # second round of authentication required
 bug.nl = 0                            # newline work-around for openconnect

--- a/gp-okta.conf
+++ b/gp-okta.conf
@@ -8,8 +8,9 @@ sms.okta = 0
 totp.okta = ABCDEFGHIJKLMNOP
 totp.google = ABCDEFGHIJKLMNOP
 gateway = Manual ny1-gw.example.com
+#cert = path-to-client-cert-as-unencrypted-pem-file.pem
 #openconnect_cmd = sudo openconnect
-openconnect_args =                    # optional arguments to openconnect
+openconnect_args =                    # optional arguments to openconnect, probably you might want to repeat the cert here (if used above) with --certificate=xxx
 execute = 0                           # execute openconnect command
 another_dance = 0                     # second round of authentication required
 bug.nl = 0                            # newline work-around for openconnect

--- a/gp-okta.conf
+++ b/gp-okta.conf
@@ -1,15 +1,24 @@
 debug = 0
+
 vpn_url = https://vpn.example.com
+#vpn_url_cert = vpn_url.cert
+
 okta_url = https://example.okta.com
+#okta_url_cert = okta_url.cert
+
 username = myuser
 password = mypass
+#client_cert = path-to-myusers-client-cert-as-unencrypted-pem-file.pem
+
 # mfa_order = totp sms
 sms.okta = 0
-totp.okta = ABCDEFGHIJKLMNOP
-totp.google = ABCDEFGHIJKLMNOP
-gateway = Manual ny1-gw.example.com
-#cert = path-to-client-cert-as-unencrypted-pem-file.pem
+#totp.okta = ABCDEFGHIJKLMNOP
+#totp.google = ABCDEFGHIJKLMNOP
+
+gateway = Manual ny1-gw.example.com   # optional hardcoded gateway
+
 #openconnect_cmd = sudo openconnect
+#openconnect_certs = path-to-a-writeable-filename-in-which-the-script-will-collect-all-involved-server-certs-if-not-set-a-temp-file-is-used-instead
 openconnect_args =                    # optional arguments to openconnect
 execute = 0                           # execute openconnect command
 another_dance = 0                     # second round of authentication required

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -248,7 +248,12 @@ def paloalto_prelogin(conf, s, gateway=None):
 	saml_req = x.find('.//saml-request')
 	if saml_req is None:
 		msg = x.find('.//msg')
-		msg = msg.text.strip() if msg is not None else 'Probably you need a certificate?'
+		if msg is not None:
+			msg = msg.text
+		if msg is not None:
+			msg = msg.strip()
+		else:
+			msg = 'Probably you need a certificate?'
 		err('did not find saml request. {0}'.format(msg))
 	if len(saml_req.text.strip()) == 0:
 		err('empty saml request')

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -154,7 +154,7 @@ def mfa_priority(conf, ftype, fprovider):
 	return priority
 
 def get_state_token(conf, c, current_url = None):
-        rx_state_token = re.search(r'var\s*stateToken\s*=\s*\'([^\']+)\'', c)
+	rx_state_token = re.search(r'var\s*stateToken\s*=\s*\'([^\']+)\'', c)
 	if not rx_state_token:
 		dbg(conf.get('debug'), 'not found', 'stateToken')
 		return None
@@ -380,15 +380,15 @@ def okta_redirect(conf, s, session_token, redirect_url):
 			url = '{0}/login/sessionCookieRedirect'.format(conf.get('okta_url'))
 			log('okta redirect request')
 			h, c = send_req(conf, s, 'redirect', url, data)
-                        state_token = get_state_token(conf, c, url)
+			state_token = get_state_token(conf, c, url)
 			redirect_url = get_redirect_url(conf, c, url)
 			if redirect_url:
 				form_url, form_data = None, {}
 			else:
 				xhtml = parse_html(c)
 				form_url, form_data = parse_form(xhtml, url)
-                        if state_token is not None:
-                                okta_auth(conf, s, state_token)
+				if state_token is not None:
+					okta_auth(conf, s, state_token)
 		elif form_url:
 			log('okta redirect form request')
 			h, c = send_req(conf, s, 'redirect form', form_url, form_data)
@@ -459,8 +459,8 @@ def main():
 	conf = load_conf(sys.argv[1])
 	
 	s = requests.Session()
-        if conf.get('cert'):
-                s.cert = conf.get('cert')
+	if conf.get('cert'):
+		s.cert = conf.get('cert')
         
 	s.headers['User-Agent'] = 'PAN GlobalProtect'
 	saml_xml = paloalto_prelogin(conf, s)

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -57,7 +57,7 @@ def dbg(d, h, *xs):
 	print('---')
 
 def err(s):
-	print('err: {0}'.format(s))
+	print('err: {0}'.format(s), file=sys.stderr)
 	sys.exit(1)
 
 def parse_xml(xml):

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -563,7 +563,6 @@ def main():
 	else:
 		pcmd = 'printf \'' + bugs + '{0}\''.format(cookie)
 	print()
-	conf['openconnect_certs'].close()
 	if conf.get('execute', '').lower() in ['1', 'true']:
 		cmd = shlex.split(cmd)
 		cmd = [os.path.expandvars(os.path.expanduser(x)) for x in cmd]

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -26,7 +26,7 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
    THE SOFTWARE.
 """
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import io, os, sys, re, json, base64, getpass, subprocess, shlex, signal
 from lxml import etree
 import requests

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -446,6 +446,9 @@ def main():
 	conf = load_conf(sys.argv[1])
 	
 	s = requests.Session()
+        if conf.get('cert'):
+                s.cert = conf.get('cert')
+        
 	s.headers['User-Agent'] = 'PAN GlobalProtect'
 	saml_xml = paloalto_prelogin(conf, s)
 	redirect_url = okta_saml(conf, s, saml_xml)

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -30,13 +30,11 @@ import requests
 import tempfile
 
 if sys.version_info >= (3,):
-	from urllib.parse import urlparse
-	from urllib.parse import urljoin
+	from urllib.parse import urlparse, urljoin
 	text_type = str
 	binary_type = bytes
 else:
-	from urlparse import urlparse
-	from urlparse import urljoin
+	from urlparse import urlparse, urljoin
 	text_type = unicode
 	binary_type = str
 	input = raw_input

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -4,6 +4,9 @@
    The MIT License (MIT)
    
    Copyright (C) 2018 Andris Raugulis (moo@arthepsy.eu)
+   Copyright (C) 2018 Nick Lanham (nick@afternight.org)
+   Copyright (C) 2019 Aaron Lindsay (aclindsa@gmail.com)
+   Copyright (C) 2019 Tino Lange (coldcoff@yahoo.com)
    
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -478,10 +478,12 @@ def paloalto_getconfig(conf, s, saml_username, prelogin_cookie):
 	if len(portal_userauthcookie) == 0:
 		err('empty portal_userauthcookie')
 	gateway = x.find('.//gateways//entry').get('name') # FIXME: this just grabs the very first, probably not what you want
-	for entry in x.find('.//root-ca'):
-		cert = entry.find('.//cert').text
-		conf['openconnect_certs'].write(to_b(cert))
-	conf['openconnect_certs'].flush()
+	xtmp = x.find('.//root-ca')
+	if xtmp is not None:
+		for entry in xtmp:
+			cert = entry.find('.//cert').text
+			conf['openconnect_certs'].write(to_b(cert))
+		conf['openconnect_certs'].flush()
 	return portal_userauthcookie, gateway
 
 # Combined first half of okta_saml with second half of okta_redirect

--- a/gp-okta.py
+++ b/gp-okta.py
@@ -490,6 +490,8 @@ def main():
 	cmd = conf.get('openconnect_cmd') or 'openconnect'
 	cmd += ' --protocol=gp -u \'{0}\''
 	cmd += ' --usergroup {1}'
+	if conf.get('cert'):
+		cmd += ' --certificate=\'{0}\''.format(conf.get('cert'))
 	cmd += ' --passwd-on-stdin ' + conf.get('openconnect_args', '') + ' \'{2}\''
 	cmd = cmd.format(username, cookie_type, conf.get('vpn_url'))
 	gw = (conf.get('gateway') or '').strip()


### PR DESCRIPTION
Hi @aclindsa,

This patch make it possible to use `gp-okta.py` with our corporate VPN.

1. rebase against changes in arthepsy:master since @aclindsas fork

2. add possibility for using a client certificate, see [Issue 17](https://github.com/arthepsy/pan-globalprotect-okta/issues/17) from @lvml.

3. Implement double `authn` login, get `stateToken` from redirects for doing an additional `authn` with Okta. (Note that we indeed need this double `authn`  *together* with your `another_dance` to connect to our corporate VPN)

Please check and probably merge with your repo, all should be backwards compatible.

Ideally this can be merged in the original @arthepsy repo with your existing [Pull Request #7](https://github.com/arthepsy/pan-globalprotect-okta/pull/7) then to fullfill @dlenski idea of a `one-globalprotect-saml-script-to-rule-them-all` script)

Thank you for all your work

Tino Lange
(coldcoff)